### PR TITLE
Improve error message for GetElementPtr source

### DIFF
--- a/ir/inst_memory.go
+++ b/ir/inst_memory.go
@@ -496,7 +496,7 @@ func (inst *InstGetElementPtr) Type() types.Type {
 			}
 			inst.ElemType = t.ElemType
 		default:
-			panic(fmt.Errorf("support for souce type %T not yet implemented", typ))
+			panic(fmt.Errorf("invalid source type; expected *types.Pointer or *types.Vector, got %T", typ))
 		}
 	}
 	// Cache type if not present.


### PR DESCRIPTION
I originally wanted to fix a small typo, but figured out the error message could be improved.

The language docs say:

>The second argument is always a pointer or a vector of pointers, and is the base address to start from.